### PR TITLE
Quickfix: bin pathes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,19 +6,22 @@ FINALIZED_PERIOD ?= 2
 help: ## Ask for help!
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+#see https://stackoverflow.com/a/26936855/1798418
+PATH  := node_modules/.bin:$(PATH)
+SHELL := /bin/bash
 
 build-purs: ## Build whole purescript src and test file
-	node_modules/.bin/pulp build --jobs 8 --src-path purs/src -I purs/test
+	pulp build --jobs 8 --src-path purs/src -I purs/test
 
 compile-contracts: ## Compile all contracts from dapp/contracts and write purescript ffi modules
 	rm -fr purs/src/Contracts
-	node_modules/.bin/chanterelle build
+	chanterelle build
 
 generate-genesis: ## Generate a cliquebait.json file
-	node_modules/.bin/chanterelle genesis --input ./cliquebait.json --output cliquebait-generated.json
+	chanterelle genesis --input ./cliquebait.json --output cliquebait-generated.json
 
 test-plasma:  ## Run the plasma e2e
-	node_modules/.bin/pulp test --src-path purs/src --test-path purs/test -m Spec.Main
+	pulp test --src-path purs/src --test-path purs/test -m Spec.Main
 
 deploy-contracts: ## Deploy contracts with local config from dapp/contracts project
-	node_modules/.bin/chanterelle deploy ./output/Plasma.Deploy/index.js
+	chanterelle deploy ./output/Plasma.Deploy/index.js


### PR DESCRIPTION
Needed by `Makefile` to run `pulp` or `chantrelle` by using local (not global) installed executables. 