### PR TITLE
Added some docker stuff and made it compatible in a networked setting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+bower_components
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:8
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+RUN npm install
+RUN ./node_modules/.bin/bower --allow-root install
+RUN make build-purs
+RUN make compile-contracts
+
+CMD echo hello

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 export
 FINALIZED_PERIOD ?= 3
 NODE_URL ?= http://localhost:8545
+PLASMA_URL ?= http://localhost:1317
 
 # plasma config vars, need to supply operator private key
 PLASMA_CONFIG_DESTINATION ?= ./plasma.toml
@@ -42,7 +43,7 @@ test-plasma:  ## Run the plasma e2e
 	NODE_URL=$(NODE_URL) pulp test -I local --test-path test -m Spec.Main
 
 deploy-contracts: compile-contracts ## Deploy contracts with local config from dapp/contracts project
-	pulp build -I src --src-path local/Plasma --modules Plasma.Deploy; NODE_URL=$(NODE_URL) chanterelle deploy ./output/Plasma.Deploy/index.js
+	pulp build -I src --src-path local/Plasma --modules Plasma.Deploy; chanterelle deploy --node-url $(NODE_URL) ./output/Plasma.Deploy/index.js
 
 deploy-and-test: deploy-contracts write-plasma-toml
 	sleep 2

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "ethjs-provider-http": "^0.1.6",
     "keccak": "^1.0.2",
     "mkdirp": "^0.5.1",
-    "purescript": "^0.12.0",
+    "purescript": "0.12.0",
     "chanterelle": "f-o-a-m/chanterelle#v2.0.2",
     "pulp": "^12.2.0",
     "purescript-psa": "^0.6.0",

--- a/test/Spec/Main.purs
+++ b/test/Spec/Main.purs
@@ -5,8 +5,9 @@ import Prelude
 import Chanterelle.Internal.Utils.Web3 (pollTransactionReceipt)
 import Chanterelle.Test (assertWeb3)
 import Data.Identity (Identity(..))
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe(..), fromMaybe, fromJust)
 import Data.Newtype (un)
+import Data.String (Pattern(..), stripPrefix)
 import Data.Time.Duration (Minutes(..), fromDuration)
 import Effect (Effect)
 import Effect.Aff (launchAff_)
@@ -20,10 +21,12 @@ import Spec.Plasma.PlasmaSpec (plasmaSpec)
 import Test.Spec.Reporter (consoleReporter)
 import Test.Spec.Runner as Runner
 import Unsafe.Coerce (unsafeCoerce)
+import Partial.Unsafe (unsafePartial)
 
 main :: Effect Unit
 main = launchAff_  do
   nodeUrl <- liftEffect $ fromMaybe "http://localhost:8545" <$> NP.lookupEnv "NODE_URL"
+  plasmaUrl <- liftEffect $ fromMaybe "http://localhost:1317" <$> NP.lookupEnv "PLASMA_URL"
   provider <- liftEffect $ httpProvider nodeUrl
   users <- mkUsers provider
   --deployResults <- buildTestConfig nodeUrl 60 Deploy.deploy'
@@ -38,7 +41,7 @@ main = launchAff_  do
   let plasmaConfig :: PlasmaSpecConfig
       plasmaConfig = { plasmaAddress: plasmaAddress
                      , clientEnv : { protocol: "http"
-                                   , baseURL: "//127.0.0.1:1317/"
+                                   , baseURL: (unsafePartial $ fromJust $ stripPrefix (Pattern "http:") plasmaUrl) <> "/"
                                    }
                      , provider
                      , users


### PR DESCRIPTION
Pretty self explanatory:

- fixed `purs` version because it uses some deprecated stuff
- made `PLASMA_URL` env var
- created a basic Dockerfile to ease dependency management for wanting to run deploy and such. This will eventually disappear, but we need it to quickly be able to re-run the demo